### PR TITLE
feat: Add graph uniformity factor

### DIFF
--- a/src/main/java/org/terasology/polyworld/IslandWorldGenerator.java
+++ b/src/main/java/org/terasology/polyworld/IslandWorldGenerator.java
@@ -83,8 +83,7 @@ public class IslandWorldGenerator extends BaseFacetedWorldGenerator {
                 .addRasterizer(new WhittakerRasterizer())
                 .addRasterizer(new RiverRasterizer())
                 .addRasterizer(new TreeRasterizer())
-                .addRasterizer(new FloraRasterizer())
-                .addPlugins();
+                .addRasterizer(new FloraRasterizer());
     }
 
     @Override

--- a/src/main/java/org/terasology/polyworld/rp/WorldRegionFacetProvider.java
+++ b/src/main/java/org/terasology/polyworld/rp/WorldRegionFacetProvider.java
@@ -87,6 +87,11 @@ public class WorldRegionFacetProvider implements ConfigurableFacetProvider {
         cache = CacheBuilder.newBuilder().maximumSize(maxCacheSize).build(loader);
     }
 
+    public WorldRegionFacetProvider(int maxCacheSize,float islandDensity) {
+        cache = CacheBuilder.newBuilder().maximumSize(maxCacheSize).build(loader);
+        configuration.islandDensity =  islandDensity;
+    }
+
     @Override
     public void setSeed(long seed) {
         this.seed = seed;


### PR DESCRIPTION
This change allows other modules using PolyWorld to change the uniformity of biome region sizes using an extra constructor defined in GraphFacetProvider.