### PR TITLE
chore: refactor `Region` to `GraphRegion`

### DIFF
--- a/src/main/java/org/terasology/polyworld/IslandWorldGenerator.java
+++ b/src/main/java/org/terasology/polyworld/IslandWorldGenerator.java
@@ -102,11 +102,11 @@ public class IslandWorldGenerator extends BaseFacetedWorldGenerator {
         GraphFacet graphs = worldRegion.getFacet(GraphFacet.class);
         WhittakerBiomeModelFacet model = worldRegion.getFacet(WhittakerBiomeModelFacet.class);
         Vector2f pos2d = new Vector2f(pos.getX(), pos.getZ());
-        CirclePickerClosest<org.terasology.polyworld.graph.Region> picker = new CirclePickerClosest<>(pos2d);
+        CirclePickerClosest<org.terasology.polyworld.graph.GraphRegion> picker = new CirclePickerClosest<>(pos2d);
 
         for (Graph g : graphs.getAllGraphs()) {
             BiomeModel biomeModel = model.get(g);
-            for (org.terasology.polyworld.graph.Region r : g.getRegions()) {
+            for (org.terasology.polyworld.graph.GraphRegion r : g.getRegions()) {
                 WhittakerBiome biome = biomeModel.getBiome(r);
                 if (!biome.equals(WhittakerBiome.OCEAN) && !biome.equals(WhittakerBiome.LAKE)) {
                     picker.offer(r.getCenter(), r);

--- a/src/main/java/org/terasology/polyworld/TriangleLookup.java
+++ b/src/main/java/org/terasology/polyworld/TriangleLookup.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
 import org.terasology.math.geom.Rect2i;
 import org.terasology.math.geom.BaseVector2f;
 import org.terasology.polyworld.graph.Graph;
-import org.terasology.polyworld.graph.Region;
+import org.terasology.polyworld.graph.GraphRegion;
 import org.terasology.polyworld.graph.Triangle;
 
 import com.google.common.base.Stopwatch;
@@ -101,12 +101,12 @@ public class TriangleLookup {
     }
 
     private static List<Triangle> drawTriangles(Graphics2D g, Graph graph) {
-        List<Region> regions = graph.getRegions();
+        List<GraphRegion> regions = graph.getRegions();
         List<Triangle> triangles = Lists.newArrayList();
 
         // index 0 is reserved for missing coverage
         int index = 1;
-        for (final Region reg : regions) {
+        for (final GraphRegion reg : regions) {
             for (Triangle tri : reg.computeTriangles()) {
                 BaseVector2f p0 = tri.getRegion().getCenter();
                 BaseVector2f p1 = tri.getCorner1().getLocation();

--- a/src/main/java/org/terasology/polyworld/biome/BiomeModel.java
+++ b/src/main/java/org/terasology/polyworld/biome/BiomeModel.java
@@ -16,11 +16,11 @@
 
 package org.terasology.polyworld.biome;
 
-import org.terasology.polyworld.graph.Region;
+import org.terasology.polyworld.graph.GraphRegion;
 
 /**
  * TODO Type description
  */
 public interface BiomeModel {
-    WhittakerBiome getBiome(Region center);
+    WhittakerBiome getBiome(GraphRegion center);
 }

--- a/src/main/java/org/terasology/polyworld/biome/DefaultBiomeModel.java
+++ b/src/main/java/org/terasology/polyworld/biome/DefaultBiomeModel.java
@@ -17,7 +17,7 @@
 package org.terasology.polyworld.biome;
 
 import org.terasology.polyworld.elevation.ElevationModel;
-import org.terasology.polyworld.graph.Region;
+import org.terasology.polyworld.graph.GraphRegion;
 import org.terasology.polyworld.moisture.MoistureModel;
 import org.terasology.polyworld.water.WaterModel;
 
@@ -40,7 +40,7 @@ public class DefaultBiomeModel implements BiomeModel {
     }
 
     @Override
-    public WhittakerBiome getBiome(Region region) {
+    public WhittakerBiome getBiome(GraphRegion region) {
         float moisture = moistureModel.getMoisture(region);
         float elevation = elevationModel.getElevation(region);
 

--- a/src/main/java/org/terasology/polyworld/biome/WhittakerBiomeProvider.java
+++ b/src/main/java/org/terasology/polyworld/biome/WhittakerBiomeProvider.java
@@ -20,7 +20,7 @@ import org.terasology.math.geom.BaseVector2i;
 import org.terasology.math.geom.Vector2i;
 import org.terasology.polyworld.graph.Graph;
 import org.terasology.polyworld.graph.GraphFacet;
-import org.terasology.polyworld.graph.Region;
+import org.terasology.polyworld.graph.GraphRegion;
 import org.terasology.polyworld.graph.Triangle;
 import org.terasology.world.generation.Border3D;
 import org.terasology.world.generation.Facet;
@@ -59,7 +59,7 @@ public class WhittakerBiomeProvider implements FacetProvider {
             }
 
             Triangle tri = graphFacet.getWorldTriangle(pos.x(), pos.y());
-            Region r = tri.getRegion();
+            GraphRegion r = tri.getRegion();
 
             WhittakerBiome biome = model.getBiome(r);
 

--- a/src/main/java/org/terasology/polyworld/elevation/AbstractElevationModel.java
+++ b/src/main/java/org/terasology/polyworld/elevation/AbstractElevationModel.java
@@ -17,7 +17,7 @@
 package org.terasology.polyworld.elevation;
 
 import org.terasology.polyworld.graph.Corner;
-import org.terasology.polyworld.graph.Region;
+import org.terasology.polyworld.graph.GraphRegion;
 
 /**
  * Implementation-independent methods for {@link ElevationModel}s
@@ -25,7 +25,7 @@ import org.terasology.polyworld.graph.Region;
 public abstract class AbstractElevationModel implements ElevationModel {
 
     @Override
-    public float getElevation(Region r) {
+    public float getElevation(GraphRegion r) {
         float total = 0;
         for (Corner c : r.getCorners()) {
             total += getElevation(c);

--- a/src/main/java/org/terasology/polyworld/elevation/ElevationModel.java
+++ b/src/main/java/org/terasology/polyworld/elevation/ElevationModel.java
@@ -17,7 +17,7 @@
 package org.terasology.polyworld.elevation;
 
 import org.terasology.polyworld.graph.Corner;
-import org.terasology.polyworld.graph.Region;
+import org.terasology.polyworld.graph.GraphRegion;
 
 /**
  * Defines elevation
@@ -34,7 +34,7 @@ public interface ElevationModel {
      * @param r the region
      * @return the
      */
-    float getElevation(Region r);
+    float getElevation(GraphRegion r);
 
     /**
      * @param c the corner of interest

--- a/src/main/java/org/terasology/polyworld/elevation/FlatLakeProvider.java
+++ b/src/main/java/org/terasology/polyworld/elevation/FlatLakeProvider.java
@@ -25,7 +25,7 @@ import java.util.function.Predicate;
 import org.terasology.polyworld.graph.Corner;
 import org.terasology.polyworld.graph.Graph;
 import org.terasology.polyworld.graph.GraphFacet;
-import org.terasology.polyworld.graph.Region;
+import org.terasology.polyworld.graph.GraphRegion;
 import org.terasology.polyworld.water.WaterModel;
 import org.terasology.polyworld.water.WaterModelFacet;
 import org.terasology.world.generation.Facet;
@@ -66,13 +66,13 @@ public class FlatLakeProvider implements FacetProvider {
     }
 
     private ElevationModel flattenLakes(Graph graph, ElevationModel elevationModel, WaterModel waterModel) {
-        Set<Region> found = Sets.newHashSet();
-        Predicate<Region> isLake = r -> waterModel.isWater(r) && !waterModel.isOcean(r);
+        Set<GraphRegion> found = Sets.newHashSet();
+        Predicate<GraphRegion> isLake = r -> waterModel.isWater(r) && !waterModel.isOcean(r);
 
         FlatLakeElevationModel flatModel = new FlatLakeElevationModel(elevationModel);
-        for (Region r : graph.getRegions()) {
+        for (GraphRegion r : graph.getRegions()) {
             if (isLake.test(r) && !found.contains(r)) {
-                Collection<Region> lake = floodFill(r, isLake);
+                Collection<GraphRegion> lake = floodFill(r, isLake);
                 flattenLake(flatModel, lake);
                 found.addAll(lake);
             }
@@ -81,16 +81,16 @@ public class FlatLakeProvider implements FacetProvider {
         return flatModel;
     }
 
-    private Collection<Region> floodFill(Region start, Predicate<Region> pred) {
-        Collection<Region> lake = new HashSet<Region>();
+    private Collection<GraphRegion> floodFill(GraphRegion start, Predicate<GraphRegion> pred) {
+        Collection<GraphRegion> lake = new HashSet<GraphRegion>();
         lake.add(start);
 
-        Deque<Region> queue = new LinkedList<>();
+        Deque<GraphRegion> queue = new LinkedList<>();
         queue.add(start);
 
         while (!queue.isEmpty()) {
-            Region next = queue.pop();
-            for (Region n : next.getNeighbors()) {
+            GraphRegion next = queue.pop();
+            for (GraphRegion n : next.getNeighbors()) {
                 if (pred.test(n) && !lake.contains(n) && !queue.contains(n)) {
                     lake.add(n);
                     queue.add(n);
@@ -100,10 +100,10 @@ public class FlatLakeProvider implements FacetProvider {
         return lake;
     }
 
-    private void flattenLake(FlatLakeElevationModel elevationModel, Collection<Region> lake) {
+    private void flattenLake(FlatLakeElevationModel elevationModel, Collection<GraphRegion> lake) {
 
         float minHeight = Float.POSITIVE_INFINITY;
-        for (Region r : lake) {
+        for (GraphRegion r : lake) {
             float elevation = elevationModel.getElevation(r);
             if (minHeight >= elevation) {
                 minHeight = elevation;
@@ -111,7 +111,7 @@ public class FlatLakeProvider implements FacetProvider {
         }
 
         // assign target height to all corners
-        for (Region r : lake) {
+        for (GraphRegion r : lake) {
             for (Corner c : r.getCorners()) {
                 elevationModel.setElevation(c, minHeight);
             }

--- a/src/main/java/org/terasology/polyworld/graph/Corner.java
+++ b/src/main/java/org/terasology/polyworld/graph/Corner.java
@@ -30,7 +30,7 @@ import com.google.common.collect.Sets;
  */
 public class Corner {
 
-    private final Set<Region> touches = Sets.newLinkedHashSet();
+    private final Set<GraphRegion> touches = Sets.newLinkedHashSet();
     private final Set<Corner> adjacent = Sets.newLinkedHashSet();
     private final Set<Edge> protrudes = Sets.newLinkedHashSet();
     private ImmutableVector2f loc;
@@ -62,7 +62,7 @@ public class Corner {
     /**
      * @param region the touching region to add (can be null or already added)
      */
-    public void addTouches(Region region) {
+    public void addTouches(GraphRegion region) {
         if (region != null) {
             touches.add(region);
         }
@@ -85,7 +85,7 @@ public class Corner {
     /**
      * @return the touches
      */
-    public Collection<Region> getTouches() {
+    public Collection<GraphRegion> getTouches() {
         return Collections.unmodifiableSet(touches);
     }
 

--- a/src/main/java/org/terasology/polyworld/graph/Edge.java
+++ b/src/main/java/org/terasology/polyworld/graph/Edge.java
@@ -24,8 +24,8 @@ import com.google.common.base.Preconditions;
  */
 public class Edge {
 
-    private final Region r0;  // Delaunay edge
-    private final Region r1;  // Delaunay edge
+    private final GraphRegion r0;  // Delaunay edge
+    private final GraphRegion r1;  // Delaunay edge
 
     private final Corner c0;  // Voronoi edge
     private final Corner c1;  // Voronoi edge
@@ -36,7 +36,7 @@ public class Edge {
      * @param r1
      * @param r0
      */
-    public Edge(Corner c0, Corner c1, Region r0, Region r1) {
+    public Edge(Corner c0, Corner c1, GraphRegion r0, GraphRegion r1) {
         Preconditions.checkArgument(c0 != null);
         Preconditions.checkArgument(c1 != null);
         Preconditions.checkArgument(r0 != null);
@@ -65,14 +65,14 @@ public class Edge {
     /**
      * @return the d1
      */
-    public Region getRegion1() {
+    public GraphRegion getRegion1() {
         return r1;
     }
 
     /**
      * @return the d0
      */
-    public Region getRegion0() {
+    public GraphRegion getRegion0() {
         return r0;
     }
 

--- a/src/main/java/org/terasology/polyworld/graph/Graph.java
+++ b/src/main/java/org/terasology/polyworld/graph/Graph.java
@@ -28,7 +28,7 @@ public interface Graph {
     /**
      * @return
      */
-    List<Region> getRegions();
+    List<GraphRegion> getRegions();
 
     /**
      * @return

--- a/src/main/java/org/terasology/polyworld/graph/GraphEditor.java
+++ b/src/main/java/org/terasology/polyworld/graph/GraphEditor.java
@@ -48,7 +48,7 @@ public final class GraphEditor {
             } else {
                 float x = 0;
                 float y = 0;
-                for (Region region : c.getTouches()) {
+                for (GraphRegion region : c.getTouches()) {
                     x += region.getCenter().getX();
                     y += region.getCenter().getY();
                 }

--- a/src/main/java/org/terasology/polyworld/graph/GraphRegion.java
+++ b/src/main/java/org/terasology/polyworld/graph/GraphRegion.java
@@ -29,18 +29,18 @@ import com.google.common.collect.Sets;
 /**
  * Defines a polygon region (vornoi region)
  */
-public class Region {
+public class GraphRegion {
 
     private final Collection<Corner> corners;
     private final Collection<Edge> borders;
-    private final Collection<Region> neighbors;
+    private final Collection<GraphRegion> neighbors;
 
     private final ImmutableVector2f center;
 
     /**
      * @param centerPos the center of the region
      */
-    public Region(ImmutableVector2f centerPos) {
+    public GraphRegion(ImmutableVector2f centerPos) {
         this.center = centerPos;
         this.corners = Sets.newTreeSet(new AngleOrdering(centerPos));
         this.borders = Sets.newLinkedHashSet();
@@ -57,7 +57,7 @@ public class Region {
     /**
      * @return an unmodifiable collection of all neighbors in insertion order
      */
-    public Collection<Region> getNeighbors() {
+    public Collection<GraphRegion> getNeighbors() {
         return Collections.unmodifiableCollection(neighbors);
     }
 
@@ -71,7 +71,7 @@ public class Region {
     /**
      * @param region the region to add (can be null or already added)
      */
-    public void addNeigbor(Region region) {
+    public void addNeigbor(GraphRegion region) {
         if (region != null) {
             neighbors.add(region);
         }

--- a/src/main/java/org/terasology/polyworld/graph/GridGraph.java
+++ b/src/main/java/org/terasology/polyworld/graph/GridGraph.java
@@ -34,7 +34,7 @@ public class GridGraph implements Graph {
     private final int cols;
 
     private final List<Corner> corners = Lists.newArrayList();
-    private final List<Region> regions = Lists.newArrayList();
+    private final List<GraphRegion> regions = Lists.newArrayList();
     private final List<Edge> edges = Lists.newArrayList();
 
     private final Rect2i bounds;
@@ -77,7 +77,7 @@ public class GridGraph implements Graph {
                 float x = bounds.minX() + (c + 0.5f) * dx;
                 float y = bounds.minY() + (r + 0.5f) * dy;
                 ImmutableVector2f pos = new ImmutableVector2f(x, y);
-                Region reg = new Region(pos);
+                GraphRegion reg = new GraphRegion(pos);
                 Corner tl = getCorner(r, c);
                 Corner tr = getCorner(r, c + 1);
                 Corner br = getCorner(r + 1, c + 1);
@@ -96,7 +96,7 @@ public class GridGraph implements Graph {
 
         for (int r = 0; r < rows; r++) {
             for (int c = 0; c < cols; c++) {
-                Region reg = getRegion(r, c);
+                GraphRegion reg = getRegion(r, c);
                 reg.addNeigbor(getRegion(r - 1, c - 1));
                 reg.addNeigbor(getRegion(r - 1, c));
                 reg.addNeigbor(getRegion(r - 1, c + 1));
@@ -112,8 +112,8 @@ public class GridGraph implements Graph {
             for (int c = 0; c < cols; c++) {
                 Corner left = getCorner(r, c);
                 Corner right = getCorner(r, c + 1);
-                Region regTop = getRegion(r - 1, c);
-                Region regBot = getRegion(r, c);
+                GraphRegion regTop = getRegion(r - 1, c);
+                GraphRegion regBot = getRegion(r, c);
 
                 Edge edge = new Edge(left, right, regTop, regBot);
                 left.addEdge(edge);
@@ -128,8 +128,8 @@ public class GridGraph implements Graph {
             for (int c = 1; c < cols; c++) {
                 Corner top = getCorner(r, c);
                 Corner bot = getCorner(r + 1, c);
-                Region regLeft = getRegion(r, c - 1);
-                Region regRight = getRegion(r, c);
+                GraphRegion regLeft = getRegion(r, c - 1);
+                GraphRegion regRight = getRegion(r, c);
 
                 Edge edge = new Edge(top, bot, regLeft, regRight);
                 top.addEdge(edge);
@@ -142,7 +142,7 @@ public class GridGraph implements Graph {
 
     }
 
-    private Region getRegion(int r, int c) {
+    private GraphRegion getRegion(int r, int c) {
         if (r < 0 || r >= rows) {
             return null;
         }
@@ -169,7 +169,7 @@ public class GridGraph implements Graph {
     }
 
     @Override
-    public List<Region> getRegions() {
+    public List<GraphRegion> getRegions() {
         return Collections.unmodifiableList(regions);
     }
 

--- a/src/main/java/org/terasology/polyworld/graph/Triangle.java
+++ b/src/main/java/org/terasology/polyworld/graph/Triangle.java
@@ -27,7 +27,7 @@ import com.google.common.base.Preconditions;
  */
 public class Triangle {
 
-    private final Region region;
+    private final GraphRegion region;
     private final Corner c1;
     private final Corner c2;
 
@@ -36,7 +36,7 @@ public class Triangle {
      * @param c1
      * @param c2
      */
-    public Triangle(Region region, Corner c1, Corner c2) {
+    public Triangle(GraphRegion region, Corner c1, Corner c2) {
         Preconditions.checkArgument(region != null);
         Preconditions.checkArgument(c1 != null);
         Preconditions.checkArgument(c2 != null);
@@ -47,7 +47,7 @@ public class Triangle {
         this.c2 = c2;
     }
 
-    public Region getRegion() {
+    public GraphRegion getRegion() {
         return region;
     }
 

--- a/src/main/java/org/terasology/polyworld/graph/VoronoiGraph.java
+++ b/src/main/java/org/terasology/polyworld/graph/VoronoiGraph.java
@@ -38,7 +38,7 @@ public class VoronoiGraph implements Graph {
 
     private final List<Edge> edges = new ArrayList<>();
     private final List<Corner> corners = new ArrayList<>();
-    private final List<Region> regions = new ArrayList<>();
+    private final List<GraphRegion> regions = new ArrayList<>();
     private final Rect2f realBounds;
     private final Rect2i intBounds;
 
@@ -51,12 +51,12 @@ public class VoronoiGraph implements Graph {
         intBounds = bounds;
         realBounds = Rect2f.createFromMinAndSize(bounds.minX(), bounds.minY(), bounds.width(), bounds.height());
 
-        final Map<Vector2f, Region> regionMap = new HashMap<>();
+        final Map<Vector2f, GraphRegion> regionMap = new HashMap<>();
         final Map<BaseVector2f, Corner> pointCornerMap = new HashMap<>();
 
         for (Vector2f vorSite : v.siteCoords()) {
             Vector2f site = transform(v.getPlotBounds(), realBounds, vorSite);
-            Region region = new Region(new ImmutableVector2f(site));
+            GraphRegion region = new GraphRegion(new ImmutableVector2f(site));
             regions.add(region);
             regionMap.put(vorSite, region);
 
@@ -80,8 +80,8 @@ public class VoronoiGraph implements Graph {
             Corner c0 = makeCorner(pointCornerMap, v.getPlotBounds(), vEdge.getStart());
             Corner c1 = makeCorner(pointCornerMap, v.getPlotBounds(), vEdge.getEnd());
 
-            Region r0 = regionMap.get(dEdge.getStart());
-            Region r1 = regionMap.get(dEdge.getEnd());
+            GraphRegion r0 = regionMap.get(dEdge.getStart());
+            GraphRegion r1 = regionMap.get(dEdge.getEnd());
 
             final Edge edge = new Edge(c0, c1, r0, r1);
 
@@ -136,7 +136,7 @@ public class VoronoiGraph implements Graph {
      * @return
      */
     @Override
-    public List<Region> getRegions() {
+    public List<GraphRegion> getRegions() {
         return Collections.unmodifiableList(regions);
     }
 

--- a/src/main/java/org/terasology/polyworld/lava/DefaultLavaModel.java
+++ b/src/main/java/org/terasology/polyworld/lava/DefaultLavaModel.java
@@ -18,7 +18,7 @@ package org.terasology.polyworld.lava;
 
 import org.terasology.polyworld.elevation.ElevationModel;
 import org.terasology.polyworld.graph.Edge;
-import org.terasology.polyworld.graph.Region;
+import org.terasology.polyworld.graph.GraphRegion;
 import org.terasology.polyworld.moisture.MoistureModel;
 import org.terasology.polyworld.rivers.RiverModel;
 import org.terasology.polyworld.water.WaterModel;
@@ -49,8 +49,8 @@ public class DefaultLavaModel implements LavaModel {
 
     @Override
     public boolean isLava(Edge edge) {
-        Region d0 = edge.getRegion0();
-        Region d1 = edge.getRegion1();
+        GraphRegion d0 = edge.getRegion0();
+        GraphRegion d1 = edge.getRegion1();
         return (riverModel.getRiverValue(edge) <= 0 && !waterModel.isWater(d0) && !waterModel.isWater(d1)
                 && elevationModel.getElevation(d0) > 0.8
                 && elevationModel.getElevation(d1) > 0.8

--- a/src/main/java/org/terasology/polyworld/moisture/DefaultMoistureModel.java
+++ b/src/main/java/org/terasology/polyworld/moisture/DefaultMoistureModel.java
@@ -25,7 +25,7 @@ import java.util.Map;
 
 import org.terasology.polyworld.graph.Corner;
 import org.terasology.polyworld.graph.Graph;
-import org.terasology.polyworld.graph.Region;
+import org.terasology.polyworld.graph.GraphRegion;
 import org.terasology.polyworld.rivers.RiverModel;
 import org.terasology.polyworld.water.WaterModel;
 import org.terasology.utilities.random.FastRandom;
@@ -150,7 +150,7 @@ public class DefaultMoistureModel implements MoistureModel {
     }
 
     @Override
-    public float getMoisture(Region r) {
+    public float getMoisture(GraphRegion r) {
         float total = 0;
         for (Corner c : r.getCorners()) {
             total += getMoisture(c);

--- a/src/main/java/org/terasology/polyworld/moisture/MoistureModel.java
+++ b/src/main/java/org/terasology/polyworld/moisture/MoistureModel.java
@@ -17,7 +17,7 @@
 package org.terasology.polyworld.moisture;
 
 import org.terasology.polyworld.graph.Corner;
-import org.terasology.polyworld.graph.Region;
+import org.terasology.polyworld.graph.GraphRegion;
 
 /**
  * TODO Type description
@@ -34,6 +34,6 @@ public interface MoistureModel {
      * @param r
      * @return
      */
-    float getMoisture(Region r);
+    float getMoisture(GraphRegion r);
 
 }

--- a/src/main/java/org/terasology/polyworld/viewer/layers/GraphFacetLayer.java
+++ b/src/main/java/org/terasology/polyworld/viewer/layers/GraphFacetLayer.java
@@ -36,7 +36,7 @@ import org.terasology.polyworld.graph.Corner;
 import org.terasology.polyworld.graph.Edge;
 import org.terasology.polyworld.graph.Graph;
 import org.terasology.polyworld.graph.GraphFacet;
-import org.terasology.polyworld.graph.Region;
+import org.terasology.polyworld.graph.GraphRegion;
 import org.terasology.polyworld.graph.Triangle;
 import org.terasology.nui.properties.Checkbox;
 import org.terasology.world.viewer.layers.AbstractFacetLayer;
@@ -122,7 +122,7 @@ public class GraphFacetLayer extends AbstractFacetLayer {
     public String getWorldText(org.terasology.world.generation.Region region, int wx, int wy) {
         GraphFacet graphFacet = region.getFacet(GraphFacet.class);
         CirclePickerClosest<Corner> cornerPicker = new CirclePickerClosest<>(new Vector2f(wx, wy), c -> 3);
-        CirclePickerClosest<Region> sitePicker = new CirclePickerClosest<>(new Vector2f(wx, wy), r -> 3);
+        CirclePickerClosest<GraphRegion> sitePicker = new CirclePickerClosest<>(new Vector2f(wx, wy), r -> 3);
         for (Graph graph : graphFacet.getAllGraphs()) {
             if (graph.getBounds().contains(wx, wy)) {
                 Triangle tri = graphFacet.getWorldTriangle(wx, wy);
@@ -216,10 +216,10 @@ public class GraphFacetLayer extends AbstractFacetLayer {
         }
     }
 
-    public static void drawPolys(Graphics2D g, Graph graph, Function<Region, Color> colorFunc) {
-        List<Region> regions = graph.getRegions();
+    public static void drawPolys(Graphics2D g, Graph graph, Function<GraphRegion, Color> colorFunc) {
+        List<GraphRegion> regions = graph.getRegions();
 
-        for (final Region reg : regions) {
+        for (final GraphRegion reg : regions) {
 
             Color col = colorFunc.apply(reg);
             Collection<Corner> pts = reg.getCorners();
@@ -240,11 +240,11 @@ public class GraphFacetLayer extends AbstractFacetLayer {
     }
 
     public static void drawTriangles(Graphics2D g, Graph graph) {
-        List<Region> regions = graph.getRegions();
+        List<GraphRegion> regions = graph.getRegions();
 
         g.setColor(new Color(64, 64, 255, 224));
 
-        for (final Region reg : regions) {
+        for (final GraphRegion reg : regions) {
             BaseVector2f p0 = reg.getCenter();
             for (Corner c : reg.getCorners()) {
                 BaseVector2f p1 = c.getLocation();
@@ -255,10 +255,10 @@ public class GraphFacetLayer extends AbstractFacetLayer {
     }
 
     public static void drawSites(Graphics2D g, Graph graph) {
-        List<Region> centers = graph.getRegions();
+        List<GraphRegion> centers = graph.getRegions();
 
         g.setColor(Color.ORANGE);
-        for (Region regs : centers) {
+        for (GraphRegion regs : centers) {
             BaseVector2f c = regs.getCenter();
             g.fill(new Rectangle2D.Double(c.getX() - 1, c.getY() - 1, 2, 2));
         }

--- a/src/main/java/org/terasology/polyworld/water/DefaultWaterModel.java
+++ b/src/main/java/org/terasology/polyworld/water/DefaultWaterModel.java
@@ -27,7 +27,7 @@ import org.terasology.math.geom.Vector2f;
 import org.terasology.polyworld.distribution.Distribution;
 import org.terasology.polyworld.graph.Corner;
 import org.terasology.polyworld.graph.Graph;
-import org.terasology.polyworld.graph.Region;
+import org.terasology.polyworld.graph.GraphRegion;
 
 import com.google.common.collect.Maps;
 
@@ -41,9 +41,9 @@ public class DefaultWaterModel implements WaterModel {
     private final Map<Corner, Boolean> cornerOcean = Maps.newHashMap();
     private final Map<Corner, Boolean> cornerCoast = Maps.newHashMap();
 
-    private final Map<Region, Boolean> regionWater = Maps.newHashMap();
-    private final Map<Region, Boolean> regionOcean = Maps.newHashMap();
-    private final Map<Region, Boolean> regionCoast = Maps.newHashMap();
+    private final Map<GraphRegion, Boolean> regionWater = Maps.newHashMap();
+    private final Map<GraphRegion, Boolean> regionOcean = Maps.newHashMap();
+    private final Map<GraphRegion, Boolean> regionCoast = Maps.newHashMap();
 
     /**
      * @param graph the graph to use
@@ -62,8 +62,8 @@ public class DefaultWaterModel implements WaterModel {
             setWater(c, dist.isInside(new Vector2f(nx, ny)));
         }
 
-        Deque<Region> queue = new LinkedList<>();
-        for (final Region region : graph.getRegions()) {
+        Deque<GraphRegion> queue = new LinkedList<>();
+        for (final GraphRegion region : graph.getRegions()) {
             int numWater = 0;
             Collection<Corner> corners = region.getCorners();
             for (final Corner c : corners) {
@@ -79,18 +79,18 @@ public class DefaultWaterModel implements WaterModel {
             setWater(region, isOcean(region) || ((float) numWater / corners.size() >= waterThreshold));
         }
         while (!queue.isEmpty()) {
-            final Region region = queue.pop();
-            for (final Region n : region.getNeighbors()) {
+            final GraphRegion region = queue.pop();
+            for (final GraphRegion n : region.getNeighbors()) {
                 if (isWater(n) && !isOcean(n)) {
                     setOcean(n, true);
                     queue.add(n);
                 }
             }
         }
-        for (Region region : graph.getRegions()) {
+        for (GraphRegion region : graph.getRegions()) {
             boolean oceanNeighbor = false;
             boolean landNeighbor = false;
-            for (Region n : region.getNeighbors()) {
+            for (GraphRegion n : region.getNeighbors()) {
                 oceanNeighbor |= isOcean(n);
                 landNeighbor |= !isWater(n);
             }
@@ -100,7 +100,7 @@ public class DefaultWaterModel implements WaterModel {
         for (Corner c : graph.getCorners()) {
             int numOcean = 0;
             int numLand = 0;
-            for (Region region : c.getTouches()) {
+            for (GraphRegion region : c.getTouches()) {
                 numOcean += isOcean(region) ? 1 : 0;
                 numLand += !isWater(region) ? 1 : 0;
             }
@@ -122,15 +122,15 @@ public class DefaultWaterModel implements WaterModel {
         cornerWater.put(c, Boolean.valueOf(water));
     }
 
-    private void setCoast(Region c, boolean coast) {
+    private void setCoast(GraphRegion c, boolean coast) {
         regionCoast.put(c, Boolean.valueOf(coast));
     }
 
-    private void setOcean(Region c, boolean ocean) {
+    private void setOcean(GraphRegion c, boolean ocean) {
         regionOcean.put(c, Boolean.valueOf(ocean));
     }
 
-    private void setWater(Region c, boolean water) {
+    private void setWater(GraphRegion c, boolean water) {
         regionWater.put(c, Boolean.valueOf(water));
     }
 
@@ -150,19 +150,19 @@ public class DefaultWaterModel implements WaterModel {
     }
 
     @Override
-    public boolean isWater(Region c) {
+    public boolean isWater(GraphRegion c) {
         Boolean val = regionWater.get(c);
         return val == null ? false : val.booleanValue();
     }
 
     @Override
-    public boolean isCoast(Region c) {
+    public boolean isCoast(GraphRegion c) {
         Boolean val = regionCoast.get(c);
         return val == null ? false : val.booleanValue();
     }
 
     @Override
-    public boolean isOcean(Region c) {
+    public boolean isOcean(GraphRegion c) {
         Boolean val = regionOcean.get(c);
         return val == null ? false : val.booleanValue();
     }

--- a/src/main/java/org/terasology/polyworld/water/PureOceanWaterModel.java
+++ b/src/main/java/org/terasology/polyworld/water/PureOceanWaterModel.java
@@ -17,7 +17,7 @@
 package org.terasology.polyworld.water;
 
 import org.terasology.polyworld.graph.Corner;
-import org.terasology.polyworld.graph.Region;
+import org.terasology.polyworld.graph.GraphRegion;
 
 /**
  * Contains only ocean water.
@@ -25,7 +25,7 @@ import org.terasology.polyworld.graph.Region;
 public class PureOceanWaterModel implements WaterModel {
 
     @Override
-    public boolean isWater(Region p) {
+    public boolean isWater(GraphRegion p) {
         return true;
     }
 
@@ -35,7 +35,7 @@ public class PureOceanWaterModel implements WaterModel {
     }
 
     @Override
-    public boolean isOcean(Region p) {
+    public boolean isOcean(GraphRegion p) {
         return true;
     }
 
@@ -45,7 +45,7 @@ public class PureOceanWaterModel implements WaterModel {
     }
 
     @Override
-    public boolean isCoast(Region p) {
+    public boolean isCoast(GraphRegion p) {
         return false;
     }
 

--- a/src/main/java/org/terasology/polyworld/water/WaterModel.java
+++ b/src/main/java/org/terasology/polyworld/water/WaterModel.java
@@ -17,7 +17,7 @@
 package org.terasology.polyworld.water;
 
 import org.terasology.polyworld.graph.Corner;
-import org.terasology.polyworld.graph.Region;
+import org.terasology.polyworld.graph.GraphRegion;
 
 /**
  * Defines how water is distributed in the graph
@@ -26,13 +26,13 @@ public interface WaterModel {
 
     boolean isWater(Corner c);
 
-    boolean isWater(Region p);
+    boolean isWater(GraphRegion p);
 
     boolean isOcean(Corner c);
 
-    boolean isOcean(Region p);
+    boolean isOcean(GraphRegion p);
 
     boolean isCoast(Corner c);
 
-    boolean isCoast(Region p);
+    boolean isCoast(GraphRegion p);
 }

--- a/src/test/java/org/terasology/polyworld/FlatLakeTest.java
+++ b/src/test/java/org/terasology/polyworld/FlatLakeTest.java
@@ -64,7 +64,7 @@ public class FlatLakeTest {
         boolean tested = false;
         for (Graph graph : graphFacet.getAllGraphs()) {
             BiomeModel biomeModel = biomeModelFacet.get(graph);
-            for (org.terasology.polyworld.graph.Region reg : graph.getRegions()) {
+            for (org.terasology.polyworld.graph.GraphRegion reg : graph.getRegions()) {
                 WhittakerBiome biome = biomeModel.getBiome(reg);
                 if (biome == WhittakerBiome.LAKE) {
                     testRegion(elevationModelFacet.get(graph), reg);
@@ -78,7 +78,7 @@ public class FlatLakeTest {
         }
     }
 
-    private void testRegion(ElevationModel elevationModel, org.terasology.polyworld.graph.Region reg) {
+    private void testRegion(ElevationModel elevationModel, org.terasology.polyworld.graph.GraphRegion reg) {
         logger.info("Testing lake at {}", reg);
 
         float centerElevation = elevationModel.getElevation(reg);

--- a/src/test/java/org/terasology/polyworld/GraphTest.java
+++ b/src/test/java/org/terasology/polyworld/GraphTest.java
@@ -28,7 +28,7 @@ import org.terasology.math.geom.Rect2f;
 import org.terasology.polyworld.graph.Corner;
 import org.terasology.polyworld.graph.Edge;
 import org.terasology.polyworld.graph.Graph;
-import org.terasology.polyworld.graph.Region;
+import org.terasology.polyworld.graph.GraphRegion;
 
 /**
  * Tests the correct representation of a {@link Graph}
@@ -68,8 +68,8 @@ public abstract class GraphTest {
     public void testGraphRelations() {
 
         for (Edge e : graph.getEdges()) {
-            Region r0 = e.getRegion0();
-            Region r1 = e.getRegion1();
+            GraphRegion r0 = e.getRegion0();
+            GraphRegion r1 = e.getRegion1();
 
             Corner c0 = e.getCorner0();
             Corner c1 = e.getCorner1();
@@ -97,7 +97,7 @@ public abstract class GraphTest {
     @Test
     public void testGraphCornerRegions() {
 
-        for (Region r : graph.getRegions()) {
+        for (GraphRegion r : graph.getRegions()) {
             Assert.assertTrue(graph.getCorners().containsAll(r.getCorners()));
         }
     }
@@ -119,7 +119,7 @@ public abstract class GraphTest {
 
     @Test
     public void testGraphRegionNeighborsSet() {
-        for (Region r : graph.getRegions()) {
+        for (GraphRegion r : graph.getRegions()) {
             Assert.assertFalse(r.getNeighbors().isEmpty());
         }
     }

--- a/src/test/java/org/terasology/polyworld/VoronoiGraphTest.java
+++ b/src/test/java/org/terasology/polyworld/VoronoiGraphTest.java
@@ -29,7 +29,7 @@ import org.terasology.math.geom.BaseVector2f;
 import org.terasology.math.geom.ImmutableVector2f;
 import org.terasology.math.geom.Rect2f;
 import org.terasology.math.geom.Vector2f;
-import org.terasology.polyworld.graph.Region;
+import org.terasology.polyworld.graph.GraphRegion;
 import org.terasology.polyworld.graph.VoronoiGraph;
 
 /**
@@ -58,9 +58,9 @@ public class VoronoiGraphTest extends GraphTest {
 
     @Test
     public void testRegionAndSiteMatch() {
-        List<Region> regions = graph.getRegions();
+        List<GraphRegion> regions = graph.getRegions();
         Assert.assertEquals("Number of regions differs from number of input sites", points.size(), regions.size());
-        for (Region reg : regions) {
+        for (GraphRegion reg : regions) {
             Assert.assertTrue(points.contains(reg.getCenter()));
         }
     }

--- a/src/test/java/org/terasology/polyworld/debug/GraphPainter.java
+++ b/src/test/java/org/terasology/polyworld/debug/GraphPainter.java
@@ -31,7 +31,7 @@ import org.terasology.math.geom.Vector2f;
 import org.terasology.polyworld.graph.Corner;
 import org.terasology.polyworld.graph.Edge;
 import org.terasology.polyworld.graph.Graph;
-import org.terasology.polyworld.graph.Region;
+import org.terasology.polyworld.graph.GraphRegion;
 import org.terasology.polyworld.graph.Triangle;
 
 import com.google.common.base.Function;
@@ -68,10 +68,10 @@ public class GraphPainter {
         }
     }
 
-    public void drawPolys(Graphics2D g, Graph graph, Function<Region, Color> colorFunc) {
-        List<Region> regions = graph.getRegions();
+    public void drawPolys(Graphics2D g, Graph graph, Function<GraphRegion, Color> colorFunc) {
+        List<GraphRegion> regions = graph.getRegions();
 
-        for (final Region reg : regions) {
+        for (final GraphRegion reg : regions) {
 
             Color col = colorFunc.apply(reg);
             Collection<Corner> pts = reg.getCorners();
@@ -92,11 +92,11 @@ public class GraphPainter {
     }
 
     public void drawTriangles(Graphics2D g, Graph graph) {
-        List<Region> regions = graph.getRegions();
+        List<GraphRegion> regions = graph.getRegions();
 
         Random r = new Random(12332434);
 
-        for (final Region reg : regions) {
+        for (final GraphRegion reg : regions) {
             for (Triangle tri : reg.computeTriangles()) {
                 g.setColor(new Color(r.nextInt(0xFFFFFF)));
                 BaseVector2f p0 = tri.getRegion().getCenter();
@@ -114,10 +114,10 @@ public class GraphPainter {
     }
 
     public void drawSites(Graphics2D g, Graph graph) {
-        List<Region> centers = graph.getRegions();
+        List<GraphRegion> centers = graph.getRegions();
 
         g.setColor(Color.BLACK);
-        for (Region s : centers) {
+        for (GraphRegion s : centers) {
             g.fillOval((int) (s.getCenter().getX() - 2), (int) (s.getCenter().getY() - 2), 4, 4);
         }
     }

--- a/src/test/java/org/terasology/polyworld/debug/RandomColors.java
+++ b/src/test/java/org/terasology/polyworld/debug/RandomColors.java
@@ -19,14 +19,14 @@ package org.terasology.polyworld.debug;
 import java.awt.Color;
 import java.util.Random;
 
-import org.terasology.polyworld.graph.Region;
+import org.terasology.polyworld.graph.GraphRegion;
 
 import com.google.common.base.Function;
 
 /**
  * TODO Type description
  */
-public class RandomColors implements Function<Region, Color> {
+public class RandomColors implements Function<GraphRegion, Color> {
     private Random r;
 
     public RandomColors() {
@@ -34,7 +34,7 @@ public class RandomColors implements Function<Region, Color> {
     }
 
     @Override
-    public Color apply(Region input) {
+    public Color apply(GraphRegion input) {
         return new Color(r.nextInt(255), r.nextInt(255), r.nextInt(255));
     }
 

--- a/src/test/java/org/terasology/polyworld/debug/SwingPreview.java
+++ b/src/test/java/org/terasology/polyworld/debug/SwingPreview.java
@@ -37,7 +37,7 @@ import org.terasology.math.geom.Vector2f;
 import org.terasology.math.geom.Vector2i;
 import org.terasology.polyworld.TriangleLookup;
 import org.terasology.polyworld.graph.Graph;
-import org.terasology.polyworld.graph.Region;
+import org.terasology.polyworld.graph.GraphRegion;
 import org.terasology.polyworld.graph.Triangle;
 import org.terasology.polyworld.graph.VoronoiGraph;
 import org.terasology.polyworld.sampling.PointSampling;


### PR DESCRIPTION
Hi! I solved the name clash and changed the Region class name to GraphRegion as suggested.

**Note: On merging this, `Lost`'s references to `PolyWorld::Region` will break and need to be adjusted to `GraphRegion`.**