### PR TITLE
refactor: component field visibility public

### DIFF
--- a/src/main/java/org/terasology/polyworld/flora/FloraProvider.java
+++ b/src/main/java/org/terasology/polyworld/flora/FloraProvider.java
@@ -114,9 +114,9 @@ public class FloraProvider extends SurfaceObjectProvider<Biome, FloraType> imple
         this.configuration = (DensityConfiguration) configuration;
     }
 
-    private static class DensityConfiguration implements Component<DensityConfiguration> {
+    public static class DensityConfiguration implements Component<DensityConfiguration> {
         @Range(min = 0, max = 1.0f, increment = 0.05f, precision = 2, description = "Define the overall flora density")
-        private float density = 0.4f;
+        public float density = 0.4f;
 
         @Override
         public void copyFrom(DensityConfiguration other) {

--- a/src/main/java/org/terasology/polyworld/flora/TreeProvider.java
+++ b/src/main/java/org/terasology/polyworld/flora/TreeProvider.java
@@ -117,9 +117,9 @@ public class TreeProvider extends SurfaceObjectProvider<WhittakerBiome, TreeGene
         this.configuration = (TreeProviderConfiguration) configuration;
     }
 
-    private static class TreeProviderConfiguration implements Component<TreeProviderConfiguration> {
+    public static class TreeProviderConfiguration implements Component<TreeProviderConfiguration> {
         @Range(min = 0, max = 1.0f, increment = 0.05f, precision = 2, description = "Define the overall tree density")
-        private float density = 0.4f;
+        public float density = 0.4f;
 
         @Override
         public void copyFrom(TreeProviderConfiguration other) {

--- a/src/main/java/org/terasology/polyworld/graph/GraphFacetProvider.java
+++ b/src/main/java/org/terasology/polyworld/graph/GraphFacetProvider.java
@@ -198,10 +198,10 @@ public class GraphFacetProvider implements ConfigurableFacetProvider {
         }
     }
 
-    private static class GraphProviderConfiguration implements Component<GraphProviderConfiguration> {
+    public static class GraphProviderConfiguration implements Component<GraphProviderConfiguration> {
         @Range(min = 0.1f, max = 10f, increment = 0.1f, precision = 1, description = "Define the density for graph " +
                 "cells")
-        private float graphDensity = 2f;
+        public float graphDensity = 2f;
 
         @Override
         public void copyFrom(GraphProviderConfiguration other) {

--- a/src/main/java/org/terasology/polyworld/rp/WorldRegionFacetProvider.java
+++ b/src/main/java/org/terasology/polyworld/rp/WorldRegionFacetProvider.java
@@ -150,13 +150,13 @@ public class WorldRegionFacetProvider implements ConfigurableFacetProvider {
         }
     }
 
-    private static class Configuration implements Component<Configuration> {
+    public static class Configuration implements Component<Configuration> {
 
         @Range(min = 50, max = 500f, increment = 10f, precision = 0, description = "Minimum size of a region")
-        private int minSize = 100;
+        public int minSize = 100;
 
         @Range(min = 0.1f, max = 1.0f, increment = 0.1f, precision = 1, description = "Define the ratio islands/water")
-        private float islandDensity = 0.7f;
+        public float islandDensity = 0.7f;
 
         @Override
         public void copyFrom(Configuration other) {


### PR DESCRIPTION
Newer Java versions are stricter with regards to access restrictions when using reflection.
This affects in particular the serialization of non-public fields in our component classes.
For this reason, we decided to exclude non-public component fields from serialization and refactor all non-public component fields to be public instead to ensure not breaking any game and especially saving/loading behavior.

A future module overhaul may have a more detailed look into the components and make considerate decisions to use non-public fields.

Relates to https://github.com/MovingBlocks/Terasology/pull/5191