### PR TITLE
build: fix mockito compilation errors in tests

### DIFF
--- a/src/test/java/org/terasology/polyworld/TinyEnvironment.java
+++ b/src/test/java/org/terasology/polyworld/TinyEnvironment.java
@@ -15,7 +15,7 @@
  */
 package org.terasology.polyworld;
 
-import org.mockito.Matchers;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 import org.terasology.engine.config.Config;
 import org.terasology.engine.context.Context;
@@ -75,8 +75,8 @@ public final class TinyEnvironment {
         air.setId((short) 0);
         air.setDisplayName("Air");
         air.setUri(BlockManager.AIR_ID);
-        Mockito.when(blockManager.getBlock(Matchers.<BlockUri>any())).thenReturn(air);
-        Mockito.when(blockManager.getBlock(Matchers.<String>any())).thenReturn(air);
+        Mockito.when(blockManager.getBlock(ArgumentMatchers.<BlockUri>any())).thenReturn(air);
+        Mockito.when(blockManager.getBlock(ArgumentMatchers.<String>any())).thenReturn(air);
 
         context.put(BlockManager.class, blockManager);
     }


### PR DESCRIPTION
This pull request fixes a compilation error which causes the unit tests to fail.

Currently CI fails with the following error:
> ```
> > Task :compileTestJava
> /home/jenkins/agent/workspace/sology_Modules_P_PolyWorld_PR-43/src/test/java/org/terasology/polyworld/TinyEnvironment.java:18: error: cannot find symbol
> import org.mockito.Matchers;
>                   ^
>   symbol:   class Matchers
>   location: package org.mockito
> /home/jenkins/agent/workspace/sology_Modules_P_PolyWorld_PR-43/src/test/java/org/terasology/polyworld/TinyEnvironment.java:78: error: cannot find symbol
>         Mockito.when(blockManager.getBlock(Matchers.<BlockUri>any())).thenReturn(air);
>                                            ^
>   symbol:   variable Matchers
>   location: class TinyEnvironment
> /home/jenkins/agent/workspace/sology_Modules_P_PolyWorld_PR-43/src/test/java/org/terasology/polyworld/TinyEnvironment.java:79: error: cannot find symbol
>         Mockito.when(blockManager.getBlock(Matchers.<String>any())).thenReturn(air);
>                                            ^
>   symbol:   variable Matchers
>   location: class TinyEnvironment
> ```

Mockito re-named its `Matchers` class to `ArgumentMatchers`. The version of Mockito in use was upgraded with the Java 17 changes.